### PR TITLE
remove validations on PID.admin_sex

### DIFF
--- a/lib/segments/gt1.rb
+++ b/lib/segments/gt1.rb
@@ -8,13 +8,7 @@ module HL7
     add_field :guarantor_home_phone
     add_field :guarantor_business_phone
     add_field :guarantor_date_of_birth
-    add_field :guarantor_sex do |sex|
-      unless /^[FMOUANC]$/.match(sex) || sex == nil || sex == ""
-        raise HL7::InvalidDataError.new( "bad administrative sex value (not F|M|O|U|A|N|C)" )
-      end
-      sex = "" unless sex
-      sex
-    end
+    add_field :guarantor_sex
     add_field :guarantor_type
     add_field :guarantor_relationship
     add_field :guarantor_ssn
@@ -72,4 +66,4 @@ module HL7
     add_field :guarantor_birth_place
     add_field :vip_indicator
   end
-end   
+end

--- a/lib/segments/pid.rb
+++ b/lib/segments/pid.rb
@@ -11,13 +11,7 @@ class HL7::Message::Segment::PID < HL7::Message::Segment
   add_field :patient_dob do |value|
     convert_to_ts(value)
   end
-  add_field :admin_sex do |sex|
-    unless /^[FMOUANCXD]$/.match(sex) || sex == nil || sex == ""
-      raise HL7::InvalidDataError.new( "bad administrative sex value (not F|M|O|U|A|N|C|X|D)" )
-    end
-    sex = "" unless sex
-    sex
-  end
+  add_field :admin_sex
   add_field :patient_alias
   add_field :race
   add_field :address

--- a/spec/basic_parsing_spec.rb
+++ b/spec/basic_parsing_spec.rb
@@ -312,12 +312,6 @@ describe HL7::Message do
       expect(msg.index(1)).to be_nil
     end
 
-    it 'validates the PID#admin_sex element' do
-      pid = HL7::Message::Segment::PID.new
-      expect { pid.admin_sex = "TEST" }.to raise_error(HL7::InvalidDataError)
-      expect { pid.admin_sex = "F" }.not_to raise_error
-    end
-
     it 'can parse an empty segment' do
       expect { HL7::Message.new @empty_segments_txt }.not_to raise_error
     end

--- a/spec/pid_segment_spec.rb
+++ b/spec/pid_segment_spec.rb
@@ -12,7 +12,7 @@ describe HL7::Message::Segment::PID do
         @base = "PID|1||333||LastName^FirstName^MiddleInitial^SR^NickName||19760228|CustomValue||2106-3^White^HL70005^CAUC^Caucasian^L||AA||||||555.55|012345678||||||||||201011110924-0700|Y|||||||||"
       end
 
-      it 'populates the admin_sex field with the correct value' do
+      it 'populates the admin_sex field with the given value' do
         pid = HL7::Message::Segment::PID.new @base
         expect(pid.admin_sex).to eq("CustomValue")
       end

--- a/spec/pid_segment_spec.rb
+++ b/spec/pid_segment_spec.rb
@@ -7,21 +7,15 @@ describe HL7::Message::Segment::PID do
       @base = "PID|1||333||LastName^FirstName^MiddleInitial^SR^NickName||19760228|F||2106-3^White^HL70005^CAUC^Caucasian^L||AA||||||555.55|012345678||||||||||201011110924-0700|Y|||||||||"
     end
 
-    it 'validates the admin_sex element' do
-      pid = HL7::Message::Segment::PID.new
-      expect do
-        vals = %w[F M O U A N C X D] + [ nil ]
-        vals.each do |x|
-          pid.admin_sex = x
-        end
-        pid.admin_sex = ""
-      end.not_to raise_error
+    context 'when the admin_sex is not a value from HL70001 (suggested values)' do
+      before do
+        @base = "PID|1||333||LastName^FirstName^MiddleInitial^SR^NickName||19760228|CustomValue||2106-3^White^HL70005^CAUC^Caucasian^L||AA||||||555.55|012345678||||||||||201011110924-0700|Y|||||||||"
+      end
 
-      expect do
-        ["TEST", "A", 1, 2].each do |x|
-          pid.admin_sex = x
-        end
-      end.to raise_error(HL7::InvalidDataError)
+      it 'populates the admin_sex field with the correct value' do
+        pid = HL7::Message::Segment::PID.new @base
+        expect(pid.admin_sex).to eq("CustomValue")
+      end
     end
 
     it "sets values correctly" do


### PR DESCRIPTION
PID-8 is a user defined table, and [HL70001](https://hl7-definition.caristix.com/v2/HL7v2.6/Tables/0001) is just a table of suggested values, so perhaps it does not make sense to validate this particular field against the HL7 standard since there is no "standard".